### PR TITLE
migrate 2025 to scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,9 @@ lazy val `advent-of-code-2024` = (project in file("2024"))
 lazy val `advent-of-code-2025` = (project in file("2025"))
   .dependsOn(core)
   .settings(
-    libraryDependencies += scalaTest % Test
+    scalaVersion := "3.3.4",
+    // Use scalatest_2.13 to match the artifact pulled from core's test scope
+    libraryDependencies += (scalaTest % Test).cross(CrossVersion.for3Use2_13)
   )
 
 lazy val `core` = (project in file("core")).settings(


### PR DESCRIPTION
# Problem
Use 
```
libraryDependencies += (scalaTest % Test).cross(CrossVersion.for3Use2_13)
```
to fix
```
[error] Modules were resolved with conflicting cross-version suffixes in ProjectRef(uri("file:/Users/yamo/projects/perso/advent-of-code/"), "advent-of-code-2025"):
[error]    org.scalatest:scalatest-featurespec _3, _2.13
[error]    org.scalatest:scalatest-shouldmatchers _3, _2.13
[error]    org.scalatest:scalatest-matchers-core _3, _2.13
[error]    org.scalatest:scalatest-diagrams _3, _2.13
[error]    org.scalatest:scalatest _3, _2.13
[error]    org.scalatest:scalatest-refspec _3, _2.13
[error]    org.scalatest:scalatest-funspec _3, _2.13
[error]    org.scalatest:scalatest-freespec _3, _2.13
[error]    org.scala-lang.modules:scala-xml _3, _2.13
[error]    org.scalatest:scalatest-propspec _3, _2.13
[error]    org.scalactic:scalactic _3, _2.13
[error]    org.scalatest:scalatest-flatspec _3, _2.13
[error]    org.scalatest:scalatest-funsuite _3, _2.13
[error]    org.scalatest:scalatest-wordspec _3, _2.13
[error]    org.scalatest:scalatest-mustmatchers _3, _2.13
[error]    org.scalatest:scalatest-core _3, _2.13
```